### PR TITLE
Update Vagrantfile

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -28,6 +28,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["bandwidthctl", :id, "add", "VagrantLimit", "--type", "network", "--limit", "1000m"]
       vb.customize ["modifyvm", :id, "--nicbandwidthgroup2", "VagrantLimit"]
       vb.memory = 8192
+      vb.customize ["modifyvm", :id, "--vram", "128"] #adjusted for windows 11 machines without processing power
       vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
     end
   end
@@ -43,6 +44,7 @@ Vagrant.configure("2") do |config|
       vb.customize ["bandwidthctl", :id, "add", "VagrantLimit", "--type", "network", "--limit", "1000m"]
       vb.customize ["modifyvm", :id, "--nicbandwidthgroup2", "VagrantLimit"]
       vb.memory = 8192
+      vb.customize ["modifyvm", :id, "--vram", "128"] #adjusted for windows 11 machines without processing power
       vb.customize ["modifyvm", :id, "--accelerate3d", "on"]
     end
   end


### PR DESCRIPTION
Added a vb.customize option that sets video memory to 128, resolving major issues with setting up vagrant VMs on Windows 11 machines.